### PR TITLE
Fix CPU monitoring interval

### DIFF
--- a/malware_dashboard.py
+++ b/malware_dashboard.py
@@ -89,11 +89,18 @@ def start_sniffer():
     sniff(prn=packet_callback, store=False)
 
 def monitor_system():
+    """Emit periodic CPU, memory and disk usage stats."""
     while True:
-        cpu = psutil.cpu_percent(interval=1)
+        # Using interval=None prevents an extra 1 second delay
+        # so updates occur every 5 seconds as intended
+        cpu = psutil.cpu_percent(interval=None)
         mem = psutil.virtual_memory().percent
         disk = psutil.disk_usage('/').percent
-        socketio.emit('system_stats', {'cpu': cpu, 'memory': mem, 'disk': disk})
+        socketio.emit('system_stats', {
+            'cpu': cpu,
+            'memory': mem,
+            'disk': disk
+        })
         time.sleep(5)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- fix CPU sampling interval so system metrics update every 5 seconds

## Testing
- `python -m py_compile malware_dashboard.py templates/malware_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_683f5c11f63c8332bd62a919353373c2